### PR TITLE
🔢 Add floating point numbers

### DIFF
--- a/bstruct/__init__.py
+++ b/bstruct/__init__.py
@@ -336,6 +336,10 @@ class Encodings:
         encode_attributes=_encode_int256,
     )
 
+    f16 = _NativeEncoding(float, format="e")
+    f32 = _NativeEncoding(float, format="f")
+    f64 = _NativeEncoding(float, format="d")
+
     I80F48 = CustomEncoding.create(
         Decimal,
         fields=[Bytes(16)],
@@ -357,6 +361,10 @@ i32 = Annotated[int, Encodings.i32]
 i64 = Annotated[int, Encodings.i64]
 i128 = Annotated[int, Encodings.i128]
 i256 = Annotated[int, Encodings.i256]
+
+f16 = Annotated[float, Encodings.f16]
+f32 = Annotated[float, Encodings.f32]
+f64 = Annotated[float, Encodings.f64]
 
 I80F48 = Annotated[Decimal, Encodings.I80F48]
 

--- a/tests/test_bstruct.py
+++ b/tests/test_bstruct.py
@@ -177,6 +177,23 @@ def test_should_encode_I80F48() -> None:
     assert decoded == original
 
 
+def test_should_encode_float() -> None:
+    @dataclass
+    class TestData:
+        f16: bstruct.f16
+        f32: bstruct.f32
+        f64: bstruct.f64
+
+    encoding = bstruct.derive(TestData)
+
+    original = TestData(0.15625, 1234.15625, 1234567.1234567)
+
+    data = encoding.encode(original)
+    decoded = encoding.decode(data)
+
+    assert decoded == original
+
+
 def test_should_encode_arrays() -> None:
     @dataclass
     class TestItem:


### PR DESCRIPTION
Closes #2.

Like all floating point numbers, there are precision cutoffs and rounding.
