### PR TITLE
✨ Support native primitive types

### DIFF
--- a/bstruct/__init__.py
+++ b/bstruct/__init__.py
@@ -390,6 +390,10 @@ def _derive(
 
     if attribute_type is bool:
         return Encodings.bool
+    elif attribute_type is int:
+        return Encodings.i32
+    elif attribute_type is float:
+        return Encodings.f64
     elif inspect.isclass(attribute_type) and dataclasses.is_dataclass(attribute_type):
         return _resolve_dataclass_encoding(attribute_type)
     elif typing.get_origin(attribute_type) is typing.Annotated:

--- a/tests/test_bstruct.py
+++ b/tests/test_bstruct.py
@@ -138,6 +138,23 @@ def test_should_encode_bytes() -> None:
     assert decoded == original
 
 
+def test_should_encode_native_types() -> None:
+    @dataclass
+    class TestData:
+        boolean: bool
+        i32: int
+        f64: float
+
+    encoding = bstruct.derive(TestData)
+
+    original = TestData(boolean=True, i32=-123456, f64=7654321.1234567)
+
+    data = encoding.encode(original)
+    decoded = encoding.decode(data)
+
+    assert decoded == original
+
+
 def test_should_encode_nested_classes() -> None:
     @dataclass
     class InnerClass:
@@ -286,12 +303,12 @@ def test_should_fail_for_wrong_data_size() -> None:
 def test_should_fail_for_missing_annotation() -> None:
     @dataclass
     class Struct:
-        value: int
+        value: complex
 
     with pytest.raises(TypeError) as exc_info:
         bstruct.derive(Struct)
 
-    assert str(exc_info.value) == "Missing annotation for type int"
+    assert str(exc_info.value) == "Missing annotation for type complex"
 
 
 def test_should_fail_for_missing_encoding() -> None:


### PR DESCRIPTION
Support native primitive built-in types *(similar to the existing `bool` implementation)*:

- `int` ➡ `bstruct.i32`
- `float` ➡ `bstruct.f64`